### PR TITLE
仮置きのフラッシュメッセージ削除

### DIFF
--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -1,6 +1,5 @@
 .flashbox
   .notice
-    グループを作成しました
 .wrapper
   .chat-side
     .side-header


### PR DESCRIPTION
#What
仮置きのHTML要素を削除しました。
#Why
フラッシュメッセージが表示できるようになったため、仮置きのHTML要素を配置してビューを確認する必要がなくなったため。